### PR TITLE
Bit more secure configuration

### DIFF
--- a/systemvm/patches/debian/config/etc/apache2/httpd.conf
+++ b/systemvm/patches/debian/config/etc/apache2/httpd.conf
@@ -1,2 +1,2 @@
-SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2
-SSLCipherSuite ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM
+SSLProtocol All -SSLv2 -SSLv3
+SSLCipherSuite AES:!kRSA:!aNULL


### PR DESCRIPTION
SSLProtocol definition inverted, so that future protocols such as TLSv1.3 will be automatically used. SSL and RC4 should not be used anymore. Included Cipher Suite that support Perfect Forward Security by not allowing anything that doesn't use Diffie-Hellman key exchange.